### PR TITLE
Fix: install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Execute:
 
 ```bash
 bundle install
-rails generate opal_stimulus:install
+rails opal_stimulus:install
 ```
 
 Start application:


### PR DESCRIPTION
Seems like `rails g opal_stimulus:install` does not work.
Tested for a fresh rails app and got:

```bash
bin/rails g opal_stimulus:install
Could not find generator 'opal_stimulus:install'. (Rails::Command::CorrectableNameError)
Run `bin/rails generate --help` for more options.
```

At same time, `bin/rails opal_stimulus:install` works well.
