### PR TITLE
Simplify installation importing `application` and `Controller` with esm

### DIFF
--- a/lib/install/install_opal_stimulus.rb
+++ b/lib/install/install_opal_stimulus.rb
@@ -7,7 +7,6 @@ if File.exist? APPLICATION_LAYOUT_PATH
   insert_into_file APPLICATION_LAYOUT_PATH, after: "<%= javascript_importmap_tags %>\n" do
     <<-ERB
     <script type="module">
-      import "application"
       import "<%= javascript_path("opal") %>"
     </script>
     ERB
@@ -22,14 +21,6 @@ if File.exist? APPLICATION_LAYOUT_PATH
 
     say "Ensure foreman is installed"
     run "gem install foreman"
-  end
-  insert_into_file Rails.root.join("app/javascript/controllers/application.js") do
-    <<-JS
-import { Controller } from "@hotwired/stimulus";
-
-window.application = application;
-window.Controller = Controller;
-    JS
   end
   append_to_file ".gitignore", "/.opal-cache\n"
   append_to_file ".gitignore", "app/assets/builds/opal.js\n"

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -14,10 +14,15 @@ namespace :opal_stimulus do
   def compile
     puts "🔨 Compiling Opal..."
 
+    Opal::Config.esm = true
     builder = Opal::Builder.new
     result = builder.build("application")
     output_path = Rails.root.join("app/assets/builds/opal.js")
-    code = result.to_s
+    code = [
+      "import { application } from 'controllers/application';",
+      "import { Controller } from '@hotwired/stimulus';",
+      result.to_s
+    ].join("\n")
 
     if Rails.env.development?
       code += "//# sourceMappingURL=/assets/opal.js.map"


### PR DESCRIPTION
This PR aims to simplify installation, now `app/javascript/controllers/application.js` will be not modified, and only compiled code will be imported inside application layout.